### PR TITLE
Allow overriding of predefined variables

### DIFF
--- a/build/newlib.6809
+++ b/build/newlib.6809
@@ -2,13 +2,12 @@
 
 set -e
 unset MAKEFLAGS
-prefix=/usr/local
-machine=m6809
-target=m6809-sim-none
-target_arg=m6809sim
-sudo=sudo
-multilib=enable
-#multilib=disable
+prefix=${prefix:-/usr/local}
+machine=${machine:-m6809}
+target=${target:-m6809-sim-none}
+target_arg=${target_arg:-m6809sim}
+sudo=${sudo:-sudo}
+multilib=${multilib:-enable}
 
 HEADERS_M="ansi.h endian.h fastmath.h ieeefp.h malloc.h param.h setjmp.h \
 	stdlib.h time.h types.h _types.h"


### PR DESCRIPTION
The ability of overriding predefined variables for prefix (and others)
makes the installation process scriptable without the need of editing
the file build/newlib.6809.

To be used in the form

    prefix=/path/to/dir ./newlib.6809 make